### PR TITLE
Make annotation for `.copy()` more precise

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def list_packages(source_path: str = src_path) -> None:
 setup(
     name="pandas-stubs",
     package_dir={"": src_path},
-    version="1.1.0.6",
+    version="1.1.0.7",
     description="Type annotations for Pandas",
     long_description=(open("README.md").read()
                       if os.path.exists("README.md") else ""),

--- a/tests/snippets/test_frame.py
+++ b/tests/snippets/test_frame.py
@@ -42,6 +42,11 @@ def test_types_to_csv_when_path_passed() -> None:
         path.unlink()
 
 
+def test_types_copy() -> None:
+    df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    df2: pd.DataFrame = df.copy()
+
+
 def test_types_getitem() -> None:
     df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 4], 5: [6, 7]})
     i = pd.Index(['col1', 'col2'])

--- a/tests/snippets/test_series.py
+++ b/tests/snippets/test_series.py
@@ -35,6 +35,11 @@ def test_types_csv() -> None:
         s4: pd.DataFrame = pd.read_csv(file.name)
 
 
+def test_types_copy() -> None:
+    s = pd.Series(data=[1, 2, 3, 4])
+    s2: pd.Series = s.copy()
+
+
 def test_types_select() -> None:
     s = pd.Series(data={'row1': 1, 'row2': 2})
     s[0]

--- a/third_party/3/pandas/core/generic.pyi
+++ b/third_party/3/pandas/core/generic.pyi
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, Callable, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, Union, AnyStr, overload
+from typing import Any, Callable, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, TypeVar, Union, AnyStr, overload
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -22,6 +22,8 @@ from pandas.core.indexes.api import Index
 from pandas.core.internals import BlockManager
 
 bool_t = bool
+
+Self = TypeVar('Self', bound=NDFrame)
 
 class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     __array_priority__: int = ...
@@ -115,7 +117,7 @@ class NDFrame(PandasObject, SelectionMixin, indexing.IndexingMixin):
     @property
     def dtypes(self) -> Any: ...
     def astype(self, dtype: Any, copy: bool_t=..., errors: str=...) -> FrameOrSeries: ...
-    def copy(self, deep: bool_t=...) -> FrameOrSeries: ...
+    def copy(self: Self, deep: bool_t=...) -> Self: ...
     def infer_objects(self) -> FrameOrSeries: ...
     def convert_dtypes(self, infer_objects: bool_t=..., convert_string: bool_t=..., convert_integer: bool_t=..., convert_boolean: bool_t=...) -> FrameOrSeries: ...
     @overload


### PR DESCRIPTION
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.copy.html
says the return value's `Object type matches caller.`

Previously, this returned a `FrameOrSeries` which was less ergonomic.
Without this fix, the newly added tests fail:

```
(venv3) aagrawal@aagrawal-mbp151 ~/src/pandas-stubs $ mypy --config-file mypy.ini third_party/3/pandas tests/snippets
tests/snippets/test_series.py:40: error: Incompatible types in assignment (expression has type "Union[DataFrame, Series]", variable has type "Series")
tests/snippets/test_frame.py:47: error: Incompatible types in assignment (expression has type "Union[DataFrame, Series]", variable has type "DataFrame")
Found 2 errors in 2 files (checked 241 source files)
```